### PR TITLE
feat: 原始数据模式下隐藏自动分段配置并禁用手动分段按钮

### DIFF
--- a/BililiveRecorder.Core/IRoom.cs
+++ b/BililiveRecorder.Core/IRoom.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using BililiveRecorder.Core.Config;
 using BililiveRecorder.Core.Config.V3;
 using BililiveRecorder.Core.Event;
 using Newtonsoft.Json.Linq;
@@ -26,6 +27,7 @@ namespace BililiveRecorder.Core
         bool Streaming { get; }
         bool DanmakuConnected { get; }
         bool AutoRecordForThisSession { get; }
+        RecordMode RecordModeForThisSession { get; }
         RoomStats Stats { get; }
 
         event EventHandler<RecordSessionStartedEventArgs>? RecordSessionStarted;

--- a/BililiveRecorder.Core/Room.cs
+++ b/BililiveRecorder.Core/Room.cs
@@ -749,6 +749,9 @@ namespace BililiveRecorder.Core
                             this.CreateAndStartNewRecordTask(skipFetchRoomInfo: false);
                     }
                     break;
+                case nameof(this.RoomConfig.RecordMode):
+                    this.OnPropertyChanged(nameof(this.RecordModeForThisSession));
+                    break;
                 default:
                     break;
             }

--- a/BililiveRecorder.Core/Room.cs
+++ b/BililiveRecorder.Core/Room.cs
@@ -120,6 +120,13 @@ namespace BililiveRecorder.Core
 
         public bool Recording => this.recordTask != null;
 
+        public RecordMode RecordModeForThisSession => this.recordTask switch
+        {
+            RawDataRecordTask => RecordMode.RawData,
+            StandardRecordTask => RecordMode.Standard,
+            _ => this.RoomConfig.RecordMode,
+        };
+
         public RoomConfig RoomConfig { get; }
         public RoomStats Stats { get; } = new RoomStats();
 
@@ -292,9 +299,8 @@ namespace BililiveRecorder.Core
                 task.RecordFileOpening += this.RecordTask_RecordFileOpening;
                 task.RecordFileClosed += this.RecordTask_RecordFileClosed;
                 task.RecordSessionEnded += this.RecordTask_RecordSessionEnded;
-                this.recordTask = task;
+                this.SetRecordTask(task);
                 this.Stats.Reset();
-                this.OnPropertyChanged(nameof(this.Recording));
 
                 _ = Task.Run(async () =>
                 {
@@ -307,8 +313,7 @@ namespace BililiveRecorder.Core
                     }
                     catch (NoMatchingQnValueException)
                     {
-                        this.recordTask = null;
-                        this.OnPropertyChanged(nameof(this.Recording));
+                        this.SetRecordTask(null);
 
                         // 无匹配的画质，重试录制之前等待更长时间
                         _ = Task.Run(() => this.RestartAfterRecordTaskFailedAsync(RestartRecordingReason.NoMatchingQnValue));
@@ -319,8 +324,7 @@ namespace BililiveRecorder.Core
                     {
                         this.logger.Write(ex is ExecutionRejectedException ? LogEventLevel.Verbose : LogEventLevel.Warning, ex, "启动录制出错");
 
-                        this.recordTask = null;
-                        this.OnPropertyChanged(nameof(this.Recording));
+                        this.SetRecordTask(null);
 
                         if (ex is IOException ioex && (ioex.HResult == HR_ERROR_DISK_FULL || ioex.HResult == HR_ERROR_HANDLE_DISK_FULL))
                         {
@@ -591,7 +595,7 @@ namespace BililiveRecorder.Core
 
             this.basicDanmakuWriter.Disable();
 
-            this.OnPropertyChanged(nameof(this.Recording));
+            this.OnRecordTaskChanged();
             this.Stats.Reset();
 
             RecordSessionEnded?.Invoke(this, new RecordSessionEndedEventArgs(this)
@@ -751,6 +755,18 @@ namespace BililiveRecorder.Core
         }
 
         #endregion
+
+        private void SetRecordTask(IRecordTask? recordTask)
+        {
+            this.recordTask = recordTask;
+            this.OnRecordTaskChanged();
+        }
+
+        private void OnRecordTaskChanged()
+        {
+            this.OnPropertyChanged(nameof(this.Recording));
+            this.OnPropertyChanged(nameof(this.RecordModeForThisSession));
+        }
 
         #region PropertyChanged
 

--- a/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
+++ b/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
@@ -75,12 +75,21 @@
                         </local:SettingWithDefault>
                     </StackPanel>
                 </GroupBox>
-                <GroupBox Header="{l:Loc Settings_Splitting_Title}">
+                <GroupBox x:Name="SplittingGroupBox" Header="{l:Loc Settings_Splitting_Title}">
+                    <GroupBox.Style>
+                        <Style TargetType="GroupBox">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding RecordMode}" Value="1">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </GroupBox.Style>
                     <StackPanel>
                         <local:SettingWithDefault IsSettingNotUsingDefault="{Binding HasCuttingMode}">
                             <StackPanel>
                                 <RadioButton GroupName="Splitting" Content="{l:Loc Settings_Splitting_RadioButton_Disabled}"
-                                 IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
+                                  IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
                         ConverterParameter={x:Static config:CuttingMode.Disabled}}" />
                                 <RadioButton GroupName="Splitting" Content="{l:Loc Settings_Splitting_RadioButton_BySize}"
                                  IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},

--- a/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
+++ b/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
@@ -1,5 +1,6 @@
 <ui:ContentDialog
     x:Class="BililiveRecorder.WPF.Controls.PerRoomSettingsDialog"
+    x:Name="RootDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -83,7 +84,7 @@
                                 <Style TargetType="TextBlock">
                                     <Setter Property="Visibility" Value="Collapsed"/>
                                     <Style.Triggers>
-                                        <DataTrigger Binding="{Binding RecordMode}" Value="{x:Static config:RecordMode.RawData}">
+                                        <DataTrigger Binding="{Binding DataContext.RecordModeForThisSession, ElementName=RootDialog}" Value="{x:Static config:RecordMode.RawData}">
                                             <Setter Property="Visibility" Value="Visible"/>
                                         </DataTrigger>
                                     </Style.Triggers>

--- a/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
+++ b/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
@@ -76,27 +76,31 @@
                     </StackPanel>
                 </GroupBox>
                 <GroupBox x:Name="SplittingGroupBox" Header="{l:Loc Settings_Splitting_Title}">
-                    <GroupBox.Style>
-                        <Style TargetType="GroupBox">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding RecordMode}" Value="1">
-                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </GroupBox.Style>
                     <StackPanel>
+                        <TextBlock Margin="0,0,0,5" FontSize="14" Foreground="DarkOrange" TextWrapping="Wrap"
+                                   Text="原始数据模式下自动分段功能不可用">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding RecordMode}" Value="{x:Static config:RecordMode.RawData}">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
                         <local:SettingWithDefault IsSettingNotUsingDefault="{Binding HasCuttingMode}">
                             <StackPanel>
                                 <RadioButton GroupName="Splitting" Content="{l:Loc Settings_Splitting_RadioButton_Disabled}"
-                                  IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
-                        ConverterParameter={x:Static config:CuttingMode.Disabled}}" />
+                                             IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
+                                    ConverterParameter={x:Static config:CuttingMode.Disabled}}" />
                                 <RadioButton GroupName="Splitting" Content="{l:Loc Settings_Splitting_RadioButton_BySize}"
-                                 IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
-                        ConverterParameter={x:Static config:CuttingMode.BySize}}" />
+                                             IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
+                                    ConverterParameter={x:Static config:CuttingMode.BySize}}" />
                                 <RadioButton GroupName="Splitting" Content="{l:Loc Settings_Splitting_RadioButton_ByTime}"
-                                 IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
-                        ConverterParameter={x:Static config:CuttingMode.ByTime}}" />
+                                             IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
+                                    ConverterParameter={x:Static config:CuttingMode.ByTime}}" />
                             </StackPanel>
                         </local:SettingWithDefault>
                         <local:SettingWithDefault IsSettingNotUsingDefault="{Binding HasCuttingNumber}">

--- a/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
+++ b/BililiveRecorder.WPF/Controls/PerRoomSettingsDialog.xaml
@@ -78,7 +78,7 @@
                 <GroupBox x:Name="SplittingGroupBox" Header="{l:Loc Settings_Splitting_Title}">
                     <StackPanel>
                         <TextBlock Margin="0,0,0,5" FontSize="14" Foreground="DarkOrange" TextWrapping="Wrap"
-                                   Text="原始数据模式下自动分段功能不可用">
+                                   Text="{l:Loc Settings_Splitting_RawDataModeWarning}">
                             <TextBlock.Style>
                                 <Style TargetType="TextBlock">
                                     <Setter Property="Visibility" Value="Collapsed"/>

--- a/BililiveRecorder.WPF/Controls/RoomCard.xaml
+++ b/BililiveRecorder.WPF/Controls/RoomCard.xaml
@@ -177,11 +177,11 @@
                         Visibility="{Binding Recording, Converter={StaticResource BooleanToVisibilityCollapsedConverter},Mode=OneWay}">
                     <Button.Style>
                         <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                            <Setter Property="ToolTip" Value="手动分段"/>
+                            <Setter Property="ToolTip" Value="{l:Loc RoomCard_SplitButton_Tooltip}"/>
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding RecordModeForThisSession}" Value="{x:Static config:RecordMode.RawData}">
                                     <Setter Property="IsEnabled" Value="False"/>
-                                    <Setter Property="ToolTip" Value="原始数据模式禁用手动分段"/>
+                                    <Setter Property="ToolTip" Value="{l:Loc RoomCard_SplitButton_Tooltip_RawDataDisabled}"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>

--- a/BililiveRecorder.WPF/Controls/RoomCard.xaml
+++ b/BililiveRecorder.WPF/Controls/RoomCard.xaml
@@ -170,9 +170,21 @@
                         </Button>
                     </Grid>
                 </Border>
-                <Button Grid.Column="2" Padding="5,3" HorizontalAlignment="Right" Margin="5,0"
-                        ToolTip="{l:Loc RoomCard_SplitButton_Tooltip}" Click="Button_Split_Click"
+                <Button x:Name="SplitButton" Grid.Column="2" Padding="5,3" HorizontalAlignment="Right" Margin="5,0"
+                        Click="Button_Split_Click"
+                        ToolTipService.ShowOnDisabled="True"
                         Visibility="{Binding Recording, Converter={StaticResource BooleanToVisibilityCollapsedConverter},Mode=OneWay}">
+                    <Button.Style>
+                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                            <Setter Property="ToolTip" Value="手动分段"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding RoomConfig.RecordMode}" Value="1">
+                                    <Setter Property="IsEnabled" Value="False"/>
+                                    <Setter Property="ToolTip" Value="原始数据模式禁用手动分段"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
                     <ui:PathIcon Width="10" Style="{StaticResource PathIconDataContentCut}"/>
                 </Button>
             </Grid>

--- a/BililiveRecorder.WPF/Controls/RoomCard.xaml
+++ b/BililiveRecorder.WPF/Controls/RoomCard.xaml
@@ -11,6 +11,7 @@
     l:ResxLocalizationProvider.DefaultDictionary="Strings"
     xmlns:local="clr-namespace:BililiveRecorder.WPF.Controls"
     xmlns:core="clr-namespace:BililiveRecorder.Core;assembly=BililiveRecorder.Core"
+    xmlns:config="clr-namespace:BililiveRecorder.Core.Config;assembly=BililiveRecorder.Core"
     d:DataContext="{d:DesignInstance core:IRoom}"
     d:DesignWidth="220" d:DesignHeight="110"
     mc:Ignorable="d">
@@ -178,7 +179,7 @@
                         <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
                             <Setter Property="ToolTip" Value="手动分段"/>
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding RoomConfig.RecordMode}" Value="1">
+                                <DataTrigger Binding="{Binding RecordModeForThisSession}" Value="{x:Static config:RecordMode.RawData}">
                                     <Setter Property="IsEnabled" Value="False"/>
                                     <Setter Property="ToolTip" Value="原始数据模式禁用手动分段"/>
                                 </DataTrigger>

--- a/BililiveRecorder.WPF/Pages/SettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/SettingsPage.xaml
@@ -59,7 +59,16 @@
                     <ui:ToggleSwitch IsOn="{Binding FlvProcessorDisableSplitOnH264AnnexB}" OnContent="使用实验性花屏修复判定逻辑" OffContent="使用实验性花屏修复判定逻辑"/>
                 </StackPanel>
             </GroupBox>
-            <GroupBox Header="{l:Loc Settings_Splitting_Title}">
+            <GroupBox x:Name="SplittingGroupBox" Header="{l:Loc Settings_Splitting_Title}">
+                <GroupBox.Style>
+                    <Style TargetType="GroupBox">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding RecordMode}" Value="1">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </GroupBox.Style>
                 <StackPanel>
                     <RadioButton GroupName="Splitting" Name="CutDisabledRadioButton" Content="{l:Loc Settings_Splitting_RadioButton_Disabled}"
                                  IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},

--- a/BililiveRecorder.WPF/Pages/SettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/SettingsPage.xaml
@@ -60,16 +60,20 @@
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Name="SplittingGroupBox" Header="{l:Loc Settings_Splitting_Title}">
-                <GroupBox.Style>
-                    <Style TargetType="GroupBox">
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding RecordMode}" Value="1">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </GroupBox.Style>
                 <StackPanel>
+                    <TextBlock Margin="0,0,0,5" FontSize="14" Foreground="DarkOrange" TextWrapping="Wrap"
+                               Text="原始数据模式下自动分段功能不可用">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding RecordMode}" Value="{x:Static config:RecordMode.RawData}">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
                     <RadioButton GroupName="Splitting" Name="CutDisabledRadioButton" Content="{l:Loc Settings_Splitting_RadioButton_Disabled}"
                                  IsChecked="{Binding Path=CuttingMode, Converter={StaticResource EnumToBooleanConverter},
                         ConverterParameter={x:Static config:CuttingMode.Disabled}}" />

--- a/BililiveRecorder.WPF/Pages/SettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/SettingsPage.xaml
@@ -62,7 +62,7 @@
             <GroupBox x:Name="SplittingGroupBox" Header="{l:Loc Settings_Splitting_Title}">
                 <StackPanel>
                     <TextBlock Margin="0,0,0,5" FontSize="14" Foreground="DarkOrange" TextWrapping="Wrap"
-                               Text="原始数据模式下自动分段功能不可用">
+                               Text="{l:Loc Settings_Splitting_RawDataModeWarning}">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Visibility" Value="Collapsed"/>

--- a/BililiveRecorder.WPF/Properties/Strings.en-PN.resx
+++ b/BililiveRecorder.WPF/Properties/Strings.en-PN.resx
@@ -277,6 +277,9 @@
   <data name="RoomCard_SplitButton_Tooltip" xml:space="preserve">
     <value>喵喵喵喵喵喵喵喵</value>
   </data>
+  <data name="RoomCard_SplitButton_Tooltip_RawDataDisabled" xml:space="preserve">
+    <value>喵喵喵喵喵喵喵喵喵</value>
+  </data>
   <data name="RoomCard_Status_AutoRecordForThisSessionDisabled_Tooltip" xml:space="preserve">
     <value>喵喵喵喵喵喵喵喵喵喵~ 喵喵喵喵喵喵喵</value>
   </data>
@@ -490,6 +493,9 @@
   <data name="Settings_Splitting_RadioButton_Disabled" xml:space="preserve">
     <value>喵喵喵喵喵</value>
   </data>
+  <data name="Settings_Splitting_ToggleSwitch_ByTitle" xml:space="preserve">
+    <value>喵喵喵喵喵喵喵喵喵喵</value>
+  </data>
   <data name="Settings_Splitting_TextBox_Left" xml:space="preserve">
     <value>喵</value>
   </data>
@@ -504,6 +510,9 @@
   </data>
   <data name="Settings_Splitting_Title" xml:space="preserve">
     <value>喵喵喵喵</value>
+  </data>
+  <data name="Settings_Splitting_RawDataModeWarning" xml:space="preserve">
+    <value>喵喵喵喵喵喵喵喵喵喵</value>
   </data>
   <data name="Settings_Webhook_Address" xml:space="preserve">
     <value>Nyahook 喵喵 喵喵喵喵</value>

--- a/BililiveRecorder.WPF/Properties/Strings.en.resx
+++ b/BililiveRecorder.WPF/Properties/Strings.en.resx
@@ -279,6 +279,9 @@ This software is open source and licensed under the GNU General Public License V
   <data name="RoomCard_SplitButton_Tooltip" xml:space="preserve">
     <value>Split recording to a new file</value>
   </data>
+  <data name="RoomCard_SplitButton_Tooltip_RawDataDisabled" xml:space="preserve">
+    <value>Manual split is disabled in Raw Data mode</value>
+  </data>
   <data name="RoomCard_Status_AutoRecordForThisSessionDisabled_Tooltip" xml:space="preserve">
     <value>Auto recording disabled for this session, will reset when stream go offline</value>
   </data>
@@ -509,6 +512,9 @@ Only FLV is supported</value>
   </data>
   <data name="Settings_Splitting_Title" xml:space="preserve">
     <value>Recording Splitting</value>
+  </data>
+  <data name="Settings_Splitting_RawDataModeWarning" xml:space="preserve">
+    <value>Auto splitting is unavailable in Raw Data mode</value>
   </data>
   <data name="Settings_Webhook_Address" xml:space="preserve">
     <value>Webhook address, one per line</value>

--- a/BililiveRecorder.WPF/Properties/Strings.ja.resx
+++ b/BililiveRecorder.WPF/Properties/Strings.ja.resx
@@ -279,6 +279,9 @@
   <data name="RoomCard_SplitButton_Tooltip" xml:space="preserve">
     <value>出力ファイルを切り抜き</value>
   </data>
+  <data name="RoomCard_SplitButton_Tooltip_RawDataDisabled" xml:space="preserve">
+    <value>オリジナルデータモードでは手動分割できません</value>
+  </data>
   <data name="RoomCard_Status_AutoRecordForThisSessionDisabled_Tooltip" xml:space="preserve">
     <value>今回の配信の自動録画が停止しました。配信終了後に再開されます</value>
   </data>
@@ -509,6 +512,9 @@ FLV フォーマットのみサポートされています。</value>
   </data>
   <data name="Settings_Splitting_Title" xml:space="preserve">
     <value>自動分割</value>
+  </data>
+  <data name="Settings_Splitting_RawDataModeWarning" xml:space="preserve">
+    <value>オリジナルデータモードでは自動分割を利用できません</value>
   </data>
   <data name="Settings_Webhook_Address" xml:space="preserve">
     <value>Webhookアドレス、１行に１つずつ</value>

--- a/BililiveRecorder.WPF/Properties/Strings.resx
+++ b/BililiveRecorder.WPF/Properties/Strings.resx
@@ -279,6 +279,9 @@
   <data name="RoomCard_SplitButton_Tooltip" xml:space="preserve">
     <value>切割录制输出文件</value>
   </data>
+  <data name="RoomCard_SplitButton_Tooltip_RawDataDisabled" xml:space="preserve">
+    <value>原始数据模式下禁用手动分段</value>
+  </data>
   <data name="RoomCard_Status_AutoRecordForThisSessionDisabled_Tooltip" xml:space="preserve">
     <value>本次直播不再自动录制，结束直播时恢复</value>
   </data>
@@ -509,6 +512,9 @@
   </data>
   <data name="Settings_Splitting_Title" xml:space="preserve">
     <value>自动分段</value>
+  </data>
+  <data name="Settings_Splitting_RawDataModeWarning" xml:space="preserve">
+    <value>原始数据模式下自动分段功能不可用</value>
   </data>
   <data name="Settings_Webhook_Address" xml:space="preserve">
     <value>Webhook 地址，一行一个</value>

--- a/BililiveRecorder.WPF/Properties/Strings.zh-Hant.resx
+++ b/BililiveRecorder.WPF/Properties/Strings.zh-Hant.resx
@@ -263,6 +263,9 @@
   <data name="RoomCard_SplitButton_Tooltip" xml:space="preserve">
     <value>切割錄製輸出文件</value>
   </data>
+  <data name="RoomCard_SplitButton_Tooltip_RawDataDisabled" xml:space="preserve">
+    <value>原始數據模式下禁用手動分段</value>
+  </data>
   <data name="RoomCard_Status_AutoRecordForThisSessionDisabled_Tooltip" xml:space="preserve">
     <value>本次直播不再自動錄製，結束直播時恢復</value>
   </data>
@@ -476,6 +479,9 @@
   
   <data name="Settings_Splitting_Title" xml:space="preserve">
     <value>自動分段</value>
+  </data>
+  <data name="Settings_Splitting_RawDataModeWarning" xml:space="preserve">
+    <value>原始數據模式下自動分段功能不可用</value>
   </data>
   <data name="Settings_Webhook_Address" xml:space="preserve">
     <value>Webhook 網址，一行一個</value>

--- a/BililiveRecorder.Web/Models/Rest/DataMappingProfile.cs
+++ b/BililiveRecorder.Web/Models/Rest/DataMappingProfile.cs
@@ -14,6 +14,7 @@ namespace BililiveRecorder.Web.Models.Rest
             this.CreateMap<IRoom, RoomDto>()
                 .ForMember(x => x.RoomId, x => x.MapFrom(s => s.RoomConfig.RoomId))
                 .ForMember(x => x.AutoRecord, x => x.MapFrom(s => s.RoomConfig.AutoRecord))
+                .ForMember(x => x.RecordMode, x => x.MapFrom(s => s.RoomConfig.RecordMode))
                 .ForMember(x => x.IoStats, x => x.MapFrom(s => s.Stats))
                 .ForMember(x => x.RecordingStats, x => x.MapFrom(s => s.Stats))
                 ;

--- a/BililiveRecorder.Web/Models/Rest/DataMappingProfile.cs
+++ b/BililiveRecorder.Web/Models/Rest/DataMappingProfile.cs
@@ -15,6 +15,7 @@ namespace BililiveRecorder.Web.Models.Rest
                 .ForMember(x => x.RoomId, x => x.MapFrom(s => s.RoomConfig.RoomId))
                 .ForMember(x => x.AutoRecord, x => x.MapFrom(s => s.RoomConfig.AutoRecord))
                 .ForMember(x => x.RecordMode, x => x.MapFrom(s => s.RoomConfig.RecordMode))
+                .ForMember(x => x.RecordModeForThisSession, x => x.MapFrom(s => s.RecordModeForThisSession))
                 .ForMember(x => x.IoStats, x => x.MapFrom(s => s.Stats))
                 .ForMember(x => x.RecordingStats, x => x.MapFrom(s => s.Stats))
                 ;

--- a/BililiveRecorder.Web/Models/Rest/RoomDto.cs
+++ b/BililiveRecorder.Web/Models/Rest/RoomDto.cs
@@ -1,4 +1,5 @@
 using System;
+using BililiveRecorder.Core.Config;
 
 namespace BililiveRecorder.Web.Models.Rest
 {
@@ -7,6 +8,7 @@ namespace BililiveRecorder.Web.Models.Rest
         public Guid ObjectId { get; set; }
         public int RoomId { get; set; }
         public bool AutoRecord { get; set; }
+        public RecordMode RecordMode { get; set; }
         public int ShortId { get; set; }
         public string? Name { get; set; }
         public long Uid { get; set; }

--- a/BililiveRecorder.Web/Models/Rest/RoomDto.cs
+++ b/BililiveRecorder.Web/Models/Rest/RoomDto.cs
@@ -9,6 +9,7 @@ namespace BililiveRecorder.Web.Models.Rest
         public int RoomId { get; set; }
         public bool AutoRecord { get; set; }
         public RecordMode RecordMode { get; set; }
+        public RecordMode RecordModeForThisSession { get; set; }
         public int ShortId { get; set; }
         public string? Name { get; set; }
         public long Uid { get; set; }

--- a/test/BililiveRecorder.Core.UnitTests/Recording/RecordModeForThisSessionTests.cs
+++ b/test/BililiveRecorder.Core.UnitTests/Recording/RecordModeForThisSessionTests.cs
@@ -37,6 +37,20 @@ namespace BililiveRecorder.Core.UnitTests.Recording
         }
 
         [Fact]
+        public void NotRecording_ConfigRecordMode_Change_Raises_PropertyChanged()
+        {
+            using var room = CreateRoom(RecordMode.Standard);
+
+            var notified = new List<string?>();
+            room.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
+
+            room.RoomConfig.RecordMode = RecordMode.RawData;
+
+            Assert.Equal(RecordMode.RawData, room.RecordModeForThisSession);
+            Assert.Contains(nameof(room.RecordModeForThisSession), notified);
+        }
+
+        [Fact]
         public void Recording_StandardRecordTask_Returns_Standard()
         {
             using var room = CreateRoom(RecordMode.RawData);

--- a/test/BililiveRecorder.Core.UnitTests/Recording/RecordModeForThisSessionTests.cs
+++ b/test/BililiveRecorder.Core.UnitTests/Recording/RecordModeForThisSessionTests.cs
@@ -1,0 +1,430 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using BililiveRecorder.Core.Api;
+using BililiveRecorder.Core.Api.Danmaku;
+using BililiveRecorder.Core.Api.Model;
+using BililiveRecorder.Core.Config;
+using BililiveRecorder.Core.Config.V3;
+using BililiveRecorder.Core.Danmaku;
+using BililiveRecorder.Core.Event;
+using BililiveRecorder.Core.Recording;
+using BililiveRecorder.Core.Scripting;
+using BililiveRecorder.Flv.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using Xunit;
+
+namespace BililiveRecorder.Core.UnitTests.Recording
+{
+    public class RecordModeForThisSessionTests
+    {
+        private const int InitDelayFactor_DontStartBackgroundTasks = 4_000_000;
+
+        [Theory]
+        [InlineData(RecordMode.Standard)]
+        [InlineData(RecordMode.RawData)]
+        public void NotRecording_Returns_ConfigRecordMode(RecordMode configRecordMode)
+        {
+            using var room = CreateRoom(configRecordMode);
+
+            Assert.False(room.Recording);
+            Assert.Equal(configRecordMode, room.RecordModeForThisSession);
+        }
+
+        [Fact]
+        public void Recording_StandardRecordTask_Returns_Standard()
+        {
+            using var room = CreateRoom(RecordMode.RawData);
+
+            InvokeSetRecordTask(room, CreateUninitializedRecordTask<StandardRecordTask>());
+
+            Assert.True(room.Recording);
+            Assert.Equal(RecordMode.Standard, room.RecordModeForThisSession);
+
+            InvokeSetRecordTask(room, null);
+        }
+
+        [Fact]
+        public void Recording_RawDataRecordTask_Returns_RawData()
+        {
+            using var room = CreateRoom(RecordMode.Standard);
+
+            InvokeSetRecordTask(room, CreateUninitializedRecordTask<RawDataRecordTask>());
+
+            Assert.True(room.Recording);
+            Assert.Equal(RecordMode.RawData, room.RecordModeForThisSession);
+
+            InvokeSetRecordTask(room, null);
+        }
+
+        [Fact]
+        public void Recording_UnknownRecordTask_FallsBack_To_ConfigRecordMode()
+        {
+            using var room = CreateRoom(RecordMode.RawData);
+
+            InvokeSetRecordTask(room, new DummyRecordTask());
+
+            Assert.True(room.Recording);
+            Assert.Equal(RecordMode.RawData, room.RecordModeForThisSession);
+        }
+
+        [Fact]
+        public void RecordModeForThisSession_Raises_PropertyChanged_On_Start_End_And_Switch()
+        {
+            using var room = CreateRoom(RecordMode.Standard);
+
+            var notified = new List<string?>();
+            room.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
+
+            InvokeSetRecordTask(room, CreateUninitializedRecordTask<StandardRecordTask>());
+
+            Assert.Equal(RecordMode.Standard, room.RecordModeForThisSession);
+            Assert.Contains(nameof(room.RecordModeForThisSession), notified);
+
+            notified.Clear();
+            InvokeSetRecordTask(room, null);
+
+            Assert.False(room.Recording);
+            Assert.Equal(RecordMode.Standard, room.RecordModeForThisSession);
+            Assert.Contains(nameof(room.RecordModeForThisSession), notified);
+
+            notified.Clear();
+            InvokeSetRecordTask(room, CreateUninitializedRecordTask<RawDataRecordTask>());
+
+            Assert.Equal(RecordMode.RawData, room.RecordModeForThisSession);
+            Assert.Contains(nameof(room.RecordModeForThisSession), notified);
+
+            InvokeSetRecordTask(room, null);
+        }
+
+        [Fact]
+        public void RecordTask_RecordSessionEnded_Raises_PropertyChanged()
+        {
+            using var room = CreateRoom(RecordMode.Standard);
+
+            InvokeSetRecordTask(room, new DummyRecordTask());
+
+            var notified = new List<string?>();
+            room.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
+
+            notified.Clear();
+            InvokePrivateMethod(room, "RecordTask_RecordSessionEnded", null, EventArgs.Empty);
+
+            Assert.False(room.Recording);
+            Assert.Equal(RecordMode.Standard, room.RecordModeForThisSession);
+            Assert.Contains(nameof(room.RecordModeForThisSession), notified);
+        }
+
+        [Fact]
+        public async Task CreateAndStartNewRecordTask_WhenStartAsyncThrowsNoMatchingQnValue_ClearsTaskAndNotifiesAsync()
+        {
+            var recordTaskFactory = new SingleRecordTaskFactory(CreateUninitializedRecordTask<NoMatchingQnValueStandardRecordTask>());
+            using var room = CreateRoom(RecordMode.Standard, recordTaskFactory);
+
+            SetPrivateField(room, "streaming", true);
+            SetPrivateField(room, "autoRecordForThisSession", false);
+
+            var notified = new List<string?>();
+            room.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
+
+            InvokePrivateMethod(room, "CreateAndStartNewRecordTask", true);
+
+            await WaitUntilAsync(() => !room.Recording, TimeSpan.FromSeconds(1));
+
+            Assert.Contains(nameof(room.RecordModeForThisSession), notified);
+            Assert.False(room.Recording);
+        }
+
+        [Fact]
+        public async Task CreateAndStartNewRecordTask_WhenStartAsyncThrowsException_ClearsTaskAndNotifiesAsync()
+        {
+            var recordTaskFactory = new SingleRecordTaskFactory(CreateUninitializedRecordTask<GenericExceptionStandardRecordTask>());
+            using var room = CreateRoom(RecordMode.Standard, recordTaskFactory);
+
+            SetPrivateField(room, "streaming", true);
+            SetPrivateField(room, "autoRecordForThisSession", false);
+
+            var notified = new List<string?>();
+            room.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
+
+            InvokePrivateMethod(room, "CreateAndStartNewRecordTask", true);
+
+            await WaitUntilAsync(() => !room.Recording, TimeSpan.FromSeconds(1));
+
+            Assert.Contains(nameof(room.RecordModeForThisSession), notified);
+            Assert.False(room.Recording);
+        }
+
+        [Fact]
+        public async Task Fallback_Switches_From_Standard_To_RawData_And_NotifiesAsync()
+        {
+            var recordTaskFactory = new FallbackRecordTaskFactory();
+            using var room = CreateRoom(RecordMode.Standard, recordTaskFactory);
+
+            SetPrivateField(room, "streaming", true);
+
+            var notified = new List<string?>();
+            room.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
+
+            InvokePrivateMethod(room, "CreateAndStartNewRecordTask", true);
+
+            Assert.Equal(RecordMode.Standard, room.RecordModeForThisSession);
+            Assert.NotNull(recordTaskFactory.StandardTask);
+            Assert.Contains(nameof(room.RecordModeForThisSession), notified);
+
+            notified.Clear();
+            room.MarkNextRecordShouldUseRawMode();
+            recordTaskFactory.StandardTask!.TriggerSessionEnded();
+
+            await WaitUntilAsync(() => room.RecordModeForThisSession == RecordMode.RawData, TimeSpan.FromSeconds(1));
+
+            Assert.NotNull(recordTaskFactory.RawDataTask);
+            Assert.Equal(new RecordMode?[] { null, RecordMode.RawData }, recordTaskFactory.RecordModeOverrides);
+            Assert.Contains(nameof(room.RecordModeForThisSession), notified);
+        }
+
+        private static Room CreateRoom(RecordMode recordMode, IRecordTaskFactory? recordTaskFactory = null)
+        {
+            var globalConfig = new GlobalConfig
+            {
+                TimingCheckInterval = 180u,
+            };
+
+            var roomConfig = new RoomConfig
+            {
+                RoomId = 123,
+                RecordMode = recordMode,
+            };
+            roomConfig.SetParent(globalConfig);
+
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .CreateLogger();
+
+            return new Room(
+                scope: new DummyServiceScope(),
+                roomConfig: roomConfig,
+                initDelayFactor: InitDelayFactor_DontStartBackgroundTasks,
+                logger: logger,
+                danmakuClient: new DummyDanmakuClient(),
+                apiClient: new DummyApiClient(),
+                basicDanmakuWriter: new DummyBasicDanmakuWriter(),
+                recordTaskFactory: recordTaskFactory ?? new DummyRecordTaskFactory(),
+                userScriptRunner: new UserScriptRunner(globalConfig));
+        }
+
+        private static TRecordTask CreateUninitializedRecordTask<TRecordTask>() where TRecordTask : IRecordTask
+        {
+#if NET6_0_OR_GREATER
+            return (TRecordTask)RuntimeHelpers.GetUninitializedObject(typeof(TRecordTask));
+#else
+            return (TRecordTask)FormatterServices.GetUninitializedObject(typeof(TRecordTask));
+#endif
+        }
+
+        private static void InvokeSetRecordTask(Room room, IRecordTask? recordTask) =>
+            InvokePrivateMethod(room, "SetRecordTask", recordTask);
+
+        private static void SetPrivateField<T>(Room room, string fieldName, T value)
+        {
+            var field = typeof(Room).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field!.SetValue(room, value);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var start = DateTimeOffset.UtcNow;
+            while (!condition())
+            {
+                if (DateTimeOffset.UtcNow - start > timeout)
+                    throw new TimeoutException($"Condition not met within {timeout}.");
+                await Task.Delay(10);
+            }
+        }
+
+        private static void InvokePrivateMethod(Room room, string methodName, params object?[] args)
+        {
+            var method = typeof(Room).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            method!.Invoke(room, args);
+        }
+
+        private sealed class DummyServiceScope : IServiceScope
+        {
+            public IServiceProvider ServiceProvider { get; } = new DummyServiceProvider();
+            public void Dispose() { }
+
+            private sealed class DummyServiceProvider : IServiceProvider
+            {
+                public object? GetService(Type serviceType) => null;
+            }
+        }
+
+        private sealed class DummyDanmakuClient : IDanmakuClient
+        {
+            public bool Connected { get; private set; }
+
+            public event EventHandler<StatusChangedEventArgs>? StatusChanged;
+            public event EventHandler<DanmakuReceivedEventArgs>? DanmakuReceived;
+
+            public Func<string, string?>? BeforeHandshake { get; set; }
+
+            public Task ConnectAsync(int roomid, DanmakuTransportMode transportMode, CancellationToken cancellationToken)
+            {
+                this.Connected = true;
+                this.StatusChanged?.Invoke(this, StatusChangedEventArgs.True);
+                return Task.CompletedTask;
+            }
+
+            public Task DisconnectAsync()
+            {
+                this.Connected = false;
+                this.StatusChanged?.Invoke(this, StatusChangedEventArgs.False);
+                return Task.CompletedTask;
+            }
+
+            public void Dispose() { }
+
+            public void RaiseDanmakuReceived(DanmakuReceivedEventArgs e) => this.DanmakuReceived?.Invoke(this, e);
+        }
+
+        private sealed class DummyApiClient : IApiClient
+        {
+            public Task<BilibiliApiResponse<RoomInfo>> GetRoomInfoAsync(int roomid) =>
+                Task.FromResult(new BilibiliApiResponse<RoomInfo> { Data = null });
+
+            public Task<BilibiliApiResponse<RoomPlayInfo>> GetStreamUrlAsync(int roomid, int qn) =>
+                Task.FromResult(new BilibiliApiResponse<RoomPlayInfo> { Data = null });
+
+            public void Dispose() { }
+        }
+
+        private sealed class DummyBasicDanmakuWriter : IBasicDanmakuWriter
+        {
+            public void Disable() { }
+            public void EnableWithPath(string path, IRoom room) { }
+            public Task WriteAsync(DanmakuModel danmakuModel) => Task.CompletedTask;
+            public void Dispose() { }
+        }
+
+        private sealed class DummyRecordTaskFactory : IRecordTaskFactory
+        {
+            public IRecordTask CreateRecordTask(IRoom room, RecordMode? recordModeOverride = null) => new DummyRecordTask();
+        }
+
+#pragma warning disable CS0067 // The event is never used
+        private sealed class DummyRecordTask : IRecordTask
+        {
+            public Guid SessionId { get; } = Guid.NewGuid();
+
+            public event EventHandler<IOStatsEventArgs>? IOStats;
+            public event EventHandler<RecordingStatsEventArgs>? RecordingStats;
+            public event EventHandler<RecordFileOpeningEventArgs>? RecordFileOpening;
+            public event EventHandler<RecordFileClosedEventArgs>? RecordFileClosed;
+            public event EventHandler? RecordSessionEnded;
+
+            public void SplitOutput() { }
+            public Task StartAsync() => Task.CompletedTask;
+            public void RequestStop() => this.RecordSessionEnded?.Invoke(this, EventArgs.Empty);
+        }
+#pragma warning restore CS0067 // The event is never used
+
+        private sealed class SingleRecordTaskFactory : IRecordTaskFactory
+        {
+            private readonly IRecordTask task;
+            public SingleRecordTaskFactory(IRecordTask task) => this.task = task;
+
+            public IRecordTask CreateRecordTask(IRoom room, RecordMode? recordModeOverride = null) => this.task;
+        }
+
+        private sealed class FallbackRecordTaskFactory : IRecordTaskFactory
+        {
+            public TestStandardRecordTask? StandardTask { get; private set; }
+            public TestRawDataRecordTask? RawDataTask { get; private set; }
+            public List<RecordMode?> RecordModeOverrides { get; } = new();
+
+            public IRecordTask CreateRecordTask(IRoom room, RecordMode? recordModeOverride = null)
+            {
+                this.RecordModeOverrides.Add(recordModeOverride);
+
+                if (recordModeOverride == RecordMode.RawData)
+                {
+                    this.RawDataTask ??= CreateUninitializedRecordTask<TestRawDataRecordTask>();
+                    return this.RawDataTask;
+                }
+
+                this.StandardTask ??= CreateUninitializedRecordTask<TestStandardRecordTask>();
+                return this.StandardTask;
+            }
+        }
+
+        private sealed class TestStandardRecordTask : StandardRecordTask
+        {
+            private TestStandardRecordTask()
+                : base(room: null!,
+                       logger: null!,
+                       builder: null!,
+                       apiClient: null!,
+                       flvTagReaderFactory: null!,
+                       tagGroupReaderFactory: null!,
+                       writerFactory: null!,
+                       userScriptRunner: null!)
+            { }
+
+            public override Task StartAsync() => Task.CompletedTask;
+            public override void RequestStop() { }
+
+            public void TriggerSessionEnded() => this.OnRecordSessionEnded(EventArgs.Empty);
+        }
+
+        private sealed class TestRawDataRecordTask : RawDataRecordTask
+        {
+            private TestRawDataRecordTask()
+                : base(room: null!, logger: null!, apiClient: null!, userScriptRunner: null!)
+            { }
+
+            public override Task StartAsync() => Task.CompletedTask;
+            public override void RequestStop() { }
+        }
+
+        private sealed class NoMatchingQnValueStandardRecordTask : StandardRecordTask
+        {
+            private NoMatchingQnValueStandardRecordTask()
+                : base(room: null!,
+                       logger: null!,
+                       builder: null!,
+                       apiClient: null!,
+                       flvTagReaderFactory: null!,
+                       tagGroupReaderFactory: null!,
+                       writerFactory: null!,
+                       userScriptRunner: null!)
+            { }
+
+            public override Task StartAsync() => Task.FromException(new NoMatchingQnValueException());
+            public override void RequestStop() { }
+        }
+
+        private sealed class GenericExceptionStandardRecordTask : StandardRecordTask
+        {
+            private GenericExceptionStandardRecordTask()
+                : base(room: null!,
+                       logger: null!,
+                       builder: null!,
+                       apiClient: null!,
+                       flvTagReaderFactory: null!,
+                       tagGroupReaderFactory: null!,
+                       writerFactory: null!,
+                       userScriptRunner: null!)
+            { }
+
+            public override Task StartAsync() => Task.FromException(new InvalidOperationException("Test exception"));
+            public override void RequestStop() { }
+        }
+    }
+}


### PR DESCRIPTION
## 功能说明
- 原始数据模式下，自动分段功能无效，因此隐藏相关 UI 配置
- 原始数据模式下，手动分段功能无效，因此禁用按钮并显示提示

## 改动内容

### 后端
- 在 RoomDto 添加 RecordMode 字段，供前端判断录制模式
- 配置 AutoMapper 映射 RecordMode 字段

### WPF
- 全局设置页和单房间设置页：原始数据模式下隐藏"自动分段" GroupBox
- 房间卡片：原始数据模式下禁用手动分段按钮，并显示 ToolTip 提示

### Web UI
- 全局设置页和单房间设置页：原始数据模式下隐藏自动分段配置区块
- 房间卡片：原始数据模式下禁用手动分段按钮，并显示 tooltip 提示
- 更新 TypeScript 类型定义

## 技术细节
- WPF 使用 DataTrigger 根据 RecordMode 控制 Visibility 和 IsEnabled
- WPF 使用 ToolTipService.ShowOnDisabled="True" 确保禁用状态下显示 ToolTip
- Web UI 使用 n-collapse-transition 和 :disabled 实现条件渲染和禁用

## 测试
- ✅ 原始数据模式下自动分段配置隐藏（WPF + Web UI）
- ✅ 原始数据模式下手动分段按钮禁用（WPF + Web UI）
- ✅ 鼠标悬停显示禁用原因提示
- ✅ 标准模式下所有功能正常

## 相关 PR
- WebUI 仓库: BililiveRecorder/BililiveRecorder-WebUI#74