### PR TITLE
fix(wpf): use GitHub raw URL for announcement to bypass Cloudflare block

### DIFF
--- a/BililiveRecorder.WPF/Pages/AnnouncementPage.xaml.cs
+++ b/BililiveRecorder.WPF/Pages/AnnouncementPage.xaml.cs
@@ -67,7 +67,7 @@ namespace BililiveRecorder.WPF.Pages
                 {
                     var uri = Program.DebugMode
                         ? $"http://rec.127-0-0-1.nip.io/wpf/announcement.php?c={CultureInfo.Name}"
-                        : $"https://raw.githubusercontent.com/BililiveRecorder/website/main/public/wpf/announcement.xml";
+                        : "https://raw.githubusercontent.com/BililiveRecorder/website/main/public/wpf/announcement.xml";
 
                     var resp = await client.GetAsync(uri);
                     var stream = await resp.EnsureSuccessStatusCode().Content.ReadAsStreamAsync();

--- a/BililiveRecorder.WPF/Pages/AnnouncementPage.xaml.cs
+++ b/BililiveRecorder.WPF/Pages/AnnouncementPage.xaml.cs
@@ -67,7 +67,7 @@ namespace BililiveRecorder.WPF.Pages
                 {
                     var uri = Program.DebugMode
                         ? $"http://rec.127-0-0-1.nip.io/wpf/announcement.php?c={CultureInfo.Name}"
-                        : $"https://rec.danmuji.org/wpf/announcement.xml?c={CultureInfo.Name}";
+                        : $"https://raw.githubusercontent.com/BililiveRecorder/website/main/public/wpf/announcement.xml";
 
                     var resp = await client.GetAsync(uri);
                     var stream = await resp.EnsureSuccessStatusCode().Content.ReadAsStreamAsync();


### PR DESCRIPTION
## Problem / 问题

`rec.danmuji.org` has Cloudflare Managed Challenge enabled, causing HttpClient requests to be intercepted with a 403 response. This prevents the WPF client's announcement page from loading.

`rec.danmuji.org` 启用了 Cloudflare Managed Challenge，HttpClient 请求被拦截返回 403，导致 WPF 客户端的公告页面始终无法加载。

## Fix / 修复

Change the announcement URL from `https://rec.danmuji.org/wpf/announcement.xml` to `https://raw.githubusercontent.com/BililiveRecorder/website/main/public/wpf/announcement.xml`, fetching the same static XML file directly from the GitHub repository to bypass Cloudflare.

将公告获取 URL 从 `https://rec.danmuji.org/wpf/announcement.xml` 改为 `https://raw.githubusercontent.com/BililiveRecorder/website/main/public/wpf/announcement.xml`，直接从 GitHub 仓库获取同一份静态 XML 文件，绕过 Cloudflare 拦截。
