### PR TITLE
Add feature: Record-Quality auto switch

### DIFF
--- a/BililiveRecorder.Cli/Configure/ConfigInstructions.gen.cs
+++ b/BililiveRecorder.Cli/Configure/ConfigInstructions.gen.cs
@@ -40,6 +40,8 @@ namespace BililiveRecorder.Cli.Configure
         TimingApiTimeout,
         TimingStreamRetry,
         TimingStreamRetryNoQn,
+        RecordingQualityUpgradeCheck,
+        TimingQualityUpgradeCheckInterval,
         TimingStreamConnect,
         TimingDanmakuRetry,
         TimingWatchdogTimeout,
@@ -104,6 +106,8 @@ namespace BililiveRecorder.Cli.Configure
             GlobalConfig.Add(GlobalConfigProperties.TimingApiTimeout, new ConfigInstruction<GlobalConfig, uint>(config => config.HasTimingApiTimeout = false, (config, value) => config.TimingApiTimeout = value) { Name = "TimingApiTimeout", CanBeOptional = true });
             GlobalConfig.Add(GlobalConfigProperties.TimingStreamRetry, new ConfigInstruction<GlobalConfig, uint>(config => config.HasTimingStreamRetry = false, (config, value) => config.TimingStreamRetry = value) { Name = "TimingStreamRetry", CanBeOptional = true });
             GlobalConfig.Add(GlobalConfigProperties.TimingStreamRetryNoQn, new ConfigInstruction<GlobalConfig, uint>(config => config.HasTimingStreamRetryNoQn = false, (config, value) => config.TimingStreamRetryNoQn = value) { Name = "TimingStreamRetryNoQn", CanBeOptional = true });
+            GlobalConfig.Add(GlobalConfigProperties.RecordingQualityUpgradeCheck, new ConfigInstruction<GlobalConfig, bool>(config => config.HasRecordingQualityUpgradeCheck = false, (config, value) => config.RecordingQualityUpgradeCheck = value) { Name = "RecordingQualityUpgradeCheck", CanBeOptional = true });
+            GlobalConfig.Add(GlobalConfigProperties.TimingQualityUpgradeCheckInterval, new ConfigInstruction<GlobalConfig, uint>(config => config.HasTimingQualityUpgradeCheckInterval = false, (config, value) => config.TimingQualityUpgradeCheckInterval = value) { Name = "TimingQualityUpgradeCheckInterval", CanBeOptional = true });
             GlobalConfig.Add(GlobalConfigProperties.TimingStreamConnect, new ConfigInstruction<GlobalConfig, uint>(config => config.HasTimingStreamConnect = false, (config, value) => config.TimingStreamConnect = value) { Name = "TimingStreamConnect", CanBeOptional = true });
             GlobalConfig.Add(GlobalConfigProperties.TimingDanmakuRetry, new ConfigInstruction<GlobalConfig, uint>(config => config.HasTimingDanmakuRetry = false, (config, value) => config.TimingDanmakuRetry = value) { Name = "TimingDanmakuRetry", CanBeOptional = true });
             GlobalConfig.Add(GlobalConfigProperties.TimingWatchdogTimeout, new ConfigInstruction<GlobalConfig, uint>(config => config.HasTimingWatchdogTimeout = false, (config, value) => config.TimingWatchdogTimeout = value) { Name = "TimingWatchdogTimeout", CanBeOptional = true });

--- a/BililiveRecorder.Core/Api/StreamQualitySelector.cs
+++ b/BililiveRecorder.Core/Api/StreamQualitySelector.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BililiveRecorder.Core.Api
+{
+    internal static class StreamQualitySelector
+    {
+        internal static readonly char[] QnParseSeparator = new[] { ',', '，', '、', ' ' };
+
+        internal static IReadOnlyList<StreamCodecQn> ParseAllowedQn(string? allowedQn)
+        {
+            if (string.IsNullOrWhiteSpace(allowedQn)) return Array.Empty<StreamCodecQn>();
+
+            var qns = allowedQn!.Split(QnParseSeparator, StringSplitOptions.RemoveEmptyEntries)
+                .Select(static x =>
+                {
+                    if (int.TryParse(x, out var num))
+                    {
+                        return new StreamCodecQn
+                        {
+                            Qn = num,
+                            Codec = StreamCodec.AVC
+                        };
+                    }
+                    else if (x.StartsWith("avc", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (int.TryParse(x[3..], out num))
+                        {
+                            return new StreamCodecQn
+                            {
+                                Qn = num,
+                                Codec = StreamCodec.AVC
+                            };
+                        }
+                    }
+                    else if (x.StartsWith("hevc", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (int.TryParse(x[4..], out num))
+                        {
+                            return new StreamCodecQn
+                            {
+                                Qn = num,
+                                Codec = StreamCodec.HEVC
+                            };
+                        }
+                    }
+
+                    // invalid
+                    return new StreamCodecQn
+                    {
+                        Qn = -1,
+                        Codec = StreamCodec.AVC
+                    };
+                })
+                .Where(x => x.Qn >= 0)
+                .ToList();
+
+            return qns;
+        }
+
+        /// <summary>
+        /// 查询当前可用的最优画质。按 allowedQn 的先后顺序（列表顺序即优先级）返回第一个可用的画质。
+        /// 无匹配时抛出 NoMatchingQnValueException。
+        /// </summary>
+        internal static async Task<StreamCodecQn> SelectBestAvailableAsync(IApiClient apiClient, IReadOnlyList<StreamCodecQn> allowedQn, int roomid)
+        {
+            const int DefaultQn = 10000;
+            var codecItems = await apiClient.GetCodecItemInStreamUrlAsync(roomid: roomid, qn: DefaultQn).ConfigureAwait(false);
+
+            var allAvailableCodecQn = new List<StreamCodecQn>();
+
+            if (codecItems.avc is not null)
+            {
+                allAvailableCodecQn.AddRange(codecItems.avc.AcceptQn.Select(x => new StreamCodecQn
+                {
+                    Codec = StreamCodec.AVC,
+                    Qn = x
+                }));
+            }
+            if (codecItems.hevc is not null)
+            {
+                allAvailableCodecQn.AddRange(codecItems.hevc.AcceptQn.Select(x => new StreamCodecQn
+                {
+                    Codec = StreamCodec.HEVC,
+                    Qn = x
+                }));
+            }
+
+            foreach (var qn in allowedQn)
+            {
+                if (allAvailableCodecQn.Contains(qn))
+                {
+                    return qn;
+                }
+            }
+
+            throw new NoMatchingQnValueException();
+        }
+
+        /// <summary>
+        /// 返回 qn 在 allowedQn 列表中的下标；不存在返回 -1。列表顺序即优先级，下标越小优先级越高。
+        /// </summary>
+        internal static int IndexOfQn(IReadOnlyList<StreamCodecQn> list, StreamCodecQn qn)
+        {
+            for (var i = 0; i < list.Count; i++)
+            {
+                if (list[i].Codec == qn.Codec && list[i].Qn == qn.Qn)
+                    return i;
+            }
+
+            return -1;
+        }
+    }
+}

--- a/BililiveRecorder.Core/Config/V3/Config.gen.cs
+++ b/BililiveRecorder.Core/Config/V3/Config.gen.cs
@@ -202,12 +202,12 @@ namespace BililiveRecorder.Core.Config.V3
         public uint TimingStreamRetryNoQn => this.GetPropertyValue<uint>();
 
         /// <summary>
-        /// 自动升级画质
+        /// 自动更新优先画质
         /// </summary>
         public bool RecordingQualityUpgradeCheck => this.GetPropertyValue<bool>();
 
         /// <summary>
-        /// 画质升级检查间隔 秒
+        /// 画质更新检查间隔 秒
         /// </summary>
         public uint TimingQualityUpgradeCheckInterval => this.GetPropertyValue<uint>();
 
@@ -470,7 +470,7 @@ namespace BililiveRecorder.Core.Config.V3
         public Optional<uint> OptionalTimingStreamRetryNoQn { get => this.GetPropertyValueOptional<uint>(nameof(this.TimingStreamRetryNoQn)); set => this.SetPropertyValueOptional(value, nameof(this.TimingStreamRetryNoQn)); }
 
         /// <summary>
-        /// 自动升级画质
+        /// 自动更新优先画质
         /// </summary>
         public bool RecordingQualityUpgradeCheck { get => this.GetPropertyValue<bool>(); set => this.SetPropertyValue(value); }
         public bool HasRecordingQualityUpgradeCheck { get => this.GetPropertyHasValue(nameof(this.RecordingQualityUpgradeCheck)); set => this.SetPropertyHasValue<bool>(value, nameof(this.RecordingQualityUpgradeCheck)); }
@@ -478,7 +478,7 @@ namespace BililiveRecorder.Core.Config.V3
         public Optional<bool> OptionalRecordingQualityUpgradeCheck { get => this.GetPropertyValueOptional<bool>(nameof(this.RecordingQualityUpgradeCheck)); set => this.SetPropertyValueOptional(value, nameof(this.RecordingQualityUpgradeCheck)); }
 
         /// <summary>
-        /// 画质升级检查间隔 秒
+        /// 画质更新检查间隔 秒
         /// </summary>
         public uint TimingQualityUpgradeCheckInterval { get => this.GetPropertyValue<uint>(); set => this.SetPropertyValue(value); }
         public bool HasTimingQualityUpgradeCheckInterval { get => this.GetPropertyHasValue(nameof(this.TimingQualityUpgradeCheckInterval)); set => this.SetPropertyHasValue<uint>(value, nameof(this.TimingQualityUpgradeCheckInterval)); }
@@ -618,7 +618,7 @@ namespace BililiveRecorder.Core.Config.V3
 
         public bool RecordingQualityUpgradeCheck => false;
 
-        public uint TimingQualityUpgradeCheckInterval => 60;
+        public uint TimingQualityUpgradeCheckInterval => 90;
 
         public uint TimingStreamConnect => 5000;
 

--- a/BililiveRecorder.Core/Config/V3/Config.gen.cs
+++ b/BililiveRecorder.Core/Config/V3/Config.gen.cs
@@ -202,6 +202,16 @@ namespace BililiveRecorder.Core.Config.V3
         public uint TimingStreamRetryNoQn => this.GetPropertyValue<uint>();
 
         /// <summary>
+        /// 自动升级画质
+        /// </summary>
+        public bool RecordingQualityUpgradeCheck => this.GetPropertyValue<bool>();
+
+        /// <summary>
+        /// 画质升级检查间隔 秒
+        /// </summary>
+        public uint TimingQualityUpgradeCheckInterval => this.GetPropertyValue<uint>();
+
+        /// <summary>
         /// 连接直播服务器超时时间 毫秒
         /// </summary>
         public uint TimingStreamConnect => this.GetPropertyValue<uint>();
@@ -460,6 +470,22 @@ namespace BililiveRecorder.Core.Config.V3
         public Optional<uint> OptionalTimingStreamRetryNoQn { get => this.GetPropertyValueOptional<uint>(nameof(this.TimingStreamRetryNoQn)); set => this.SetPropertyValueOptional(value, nameof(this.TimingStreamRetryNoQn)); }
 
         /// <summary>
+        /// 自动升级画质
+        /// </summary>
+        public bool RecordingQualityUpgradeCheck { get => this.GetPropertyValue<bool>(); set => this.SetPropertyValue(value); }
+        public bool HasRecordingQualityUpgradeCheck { get => this.GetPropertyHasValue(nameof(this.RecordingQualityUpgradeCheck)); set => this.SetPropertyHasValue<bool>(value, nameof(this.RecordingQualityUpgradeCheck)); }
+        [JsonProperty(nameof(RecordingQualityUpgradeCheck)), EditorBrowsable(EditorBrowsableState.Never)]
+        public Optional<bool> OptionalRecordingQualityUpgradeCheck { get => this.GetPropertyValueOptional<bool>(nameof(this.RecordingQualityUpgradeCheck)); set => this.SetPropertyValueOptional(value, nameof(this.RecordingQualityUpgradeCheck)); }
+
+        /// <summary>
+        /// 画质升级检查间隔 秒
+        /// </summary>
+        public uint TimingQualityUpgradeCheckInterval { get => this.GetPropertyValue<uint>(); set => this.SetPropertyValue(value); }
+        public bool HasTimingQualityUpgradeCheckInterval { get => this.GetPropertyHasValue(nameof(this.TimingQualityUpgradeCheckInterval)); set => this.SetPropertyHasValue<uint>(value, nameof(this.TimingQualityUpgradeCheckInterval)); }
+        [JsonProperty(nameof(TimingQualityUpgradeCheckInterval)), EditorBrowsable(EditorBrowsableState.Never)]
+        public Optional<uint> OptionalTimingQualityUpgradeCheckInterval { get => this.GetPropertyValueOptional<uint>(nameof(this.TimingQualityUpgradeCheckInterval)); set => this.SetPropertyValueOptional(value, nameof(this.TimingQualityUpgradeCheckInterval)); }
+
+        /// <summary>
         /// 连接直播服务器超时时间 毫秒
         /// </summary>
         public uint TimingStreamConnect { get => this.GetPropertyValue<uint>(); set => this.SetPropertyValue(value); }
@@ -589,6 +615,10 @@ namespace BililiveRecorder.Core.Config.V3
         public uint TimingStreamRetry => 6000;
 
         public uint TimingStreamRetryNoQn => 90;
+
+        public bool RecordingQualityUpgradeCheck => false;
+
+        public uint TimingQualityUpgradeCheckInterval => 60;
 
         public uint TimingStreamConnect => 5000;
 

--- a/BililiveRecorder.Core/Recording/IRecordTask.cs
+++ b/BililiveRecorder.Core/Recording/IRecordTask.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using BililiveRecorder.Core.Api;
 using BililiveRecorder.Core.Event;
 
 namespace BililiveRecorder.Core.Recording
@@ -7,6 +8,8 @@ namespace BililiveRecorder.Core.Recording
     internal interface IRecordTask
     {
         Guid SessionId { get; }
+
+        StreamCodecQn CurrentCodecQn { get; }
 
         event EventHandler<IOStatsEventArgs>? IOStats;
         event EventHandler<RecordingStatsEventArgs>? RecordingStats;

--- a/BililiveRecorder.Core/Recording/RecordTaskBase.cs
+++ b/BililiveRecorder.Core/Recording/RecordTaskBase.cs
@@ -45,6 +45,7 @@ namespace BililiveRecorder.Core.Recording
         protected bool started = false;
         protected bool timeoutTriggered = false;
         protected int qn;
+        public StreamCodecQn CurrentCodecQn { get; protected set; }
 
         private readonly object ioStatsLock = new();
         protected int ioNetworkDownloadedBytes;
@@ -98,13 +99,14 @@ namespace BililiveRecorder.Core.Recording
                 throw new InvalidOperationException("Only one StartAsync call allowed per instance.");
             this.started = true;
 
-            var (fullUrl, codecQn) = await this.FetchStreamUrlAsync(this.room.RoomConfig.RoomId).ConfigureAwait(false);
+            var (fullUrl, selectedCodecQn, currentCodecQn) = await this.FetchStreamUrlAsync(this.room.RoomConfig.RoomId).ConfigureAwait(false);
 
-            this.qn = codecQn.Qn;
+            this.qn = currentCodecQn.Qn;
+            this.CurrentCodecQn = selectedCodecQn;
             this.streamHost = new Uri(fullUrl).Host;
-            var qnDesc = StreamQualityNumber.MapToString(codecQn.Qn);
+            var qnDesc = StreamQualityNumber.MapToString(currentCodecQn.Qn);
 
-            this.logger.Information("连接直播服务器 {Host} 录制画质 {Qn} ({QnDescription})", this.streamHost, codecQn, qnDesc);
+            this.logger.Information("连接直播服务器 {Host} 录制画质 {Qn} ({QnDescription})", this.streamHost, currentCodecQn, qnDesc);
             this.logger.Debug("直播流地址 {Url}", fullUrl);
 
             var stream = await this.GetStreamAsync(fullUrl: fullUrl, timeout: (int)this.room.RoomConfig.TimingStreamConnect).ConfigureAwait(false);
@@ -229,114 +231,33 @@ namespace BililiveRecorder.Core.Recording
             return httpClient;
         }
 
-        internal static readonly char[] QnParseSeparator = new[] { ',', '，', '、', ' ' };
-        private static IReadOnlyList<StreamCodecQn> ParseAllowedQn(string? allowedQn)
+        protected async Task<(string url, StreamCodecQn selectedCodecQn, StreamCodecQn currentCodecQn)> FetchStreamUrlAsync(int roomid)
         {
-            if (string.IsNullOrWhiteSpace(allowedQn)) return Array.Empty<StreamCodecQn>();
-
-            var qns = allowedQn!.Split(QnParseSeparator, StringSplitOptions.RemoveEmptyEntries)
-                .Select(static x =>
-                {
-                    if (int.TryParse(x, out var num))
-                    {
-                        return new StreamCodecQn
-                        {
-                            Qn = num,
-                            Codec = StreamCodec.AVC
-                        };
-                    }
-                    else if (x.StartsWith("avc", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (int.TryParse(x[3..], out num))
-                        {
-                            return new StreamCodecQn
-                            {
-                                Qn = num,
-                                Codec = StreamCodec.AVC
-                            };
-                        }
-                    }
-                    else if (x.StartsWith("hevc", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (int.TryParse(x[4..], out num))
-                        {
-                            return new StreamCodecQn
-                            {
-                                Qn = num,
-                                Codec = StreamCodec.HEVC
-                            };
-                        }
-                    }
-
-                    // invalid
-                    return new StreamCodecQn
-                    {
-                        Qn = -1,
-                        Codec = StreamCodec.AVC
-                    };
-                })
-                .Where(x => x.Qn >= 0)
-                .ToList();
-
-            return qns;
-        }
-
-        protected async Task<(string url, StreamCodecQn codecQn)> FetchStreamUrlAsync(int roomid)
-        {
-            var allowedQn = ParseAllowedQn(this.room.RoomConfig.RecordingQuality);
+            var allowedQn = StreamQualitySelector.ParseAllowedQn(this.room.RoomConfig.RecordingQuality);
 
             // 优先使用用户脚本获取直播流地址
             if (this.userScriptRunner.CallOnFetchStreamUrl(this.logger, roomid, allowedQn) is { } urlFromScript)
             {
                 this.logger.Information("使用用户脚本返回的直播流地址 {Url}", urlFromScript);
-                return (urlFromScript, new StreamCodecQn { Codec = StreamCodec.AVC, Qn = -1 });
-            }
-
-            const int DefaultQn = 10000;
-            var codecItems = await this.apiClient.GetCodecItemInStreamUrlAsync(roomid: roomid, qn: DefaultQn).ConfigureAwait(false);
-            //?? throw new Exception("no supported stream url, qn: " + DefaultQn);
-
-            var allAvailableCodecQn = new List<StreamCodecQn>();
-
-            if (codecItems.avc is not null)
-            {
-                allAvailableCodecQn.AddRange(codecItems.avc.AcceptQn.Select(x => new StreamCodecQn
-                {
-                    Codec = StreamCodec.AVC,
-                    Qn = x
-                }));
-            }
-            if (codecItems.hevc is not null)
-            {
-                allAvailableCodecQn.AddRange(codecItems.hevc.AcceptQn.Select(x => new StreamCodecQn
-                {
-                    Codec = StreamCodec.HEVC,
-                    Qn = x
-                }));
+                var scriptQn = new StreamCodecQn { Codec = StreamCodec.AVC, Qn = -1 };
+                return (urlFromScript, scriptQn, scriptQn);
             }
 
             StreamCodecQn selectedCodecQn;
-            // Select first avaiable qn
-            foreach (var qn in allowedQn)
+            try
             {
-                if (allAvailableCodecQn.Contains(qn))
-                {
-                    selectedCodecQn = qn;
-                    goto match_qn_success;
-                }
+                selectedCodecQn = await StreamQualitySelector.SelectBestAvailableAsync(this.apiClient, allowedQn, roomid).ConfigureAwait(false);
+            }
+            catch (NoMatchingQnValueException)
+            {
+                this.logger.Information("没有符合设置要求的画质，稍后再试。设置画质 {QnSettings}", allowedQn);
+                throw;
             }
 
-            this.logger.Information("没有符合设置要求的画质，稍后再试。设置画质 {QnSettings}, 可用画质 {AcceptQn}", allowedQn, allAvailableCodecQn);
-            throw new NoMatchingQnValueException();
+            this.logger.Debug("设置画质 {QnSettings}, 最终选择 {SelectedQn}", allowedQn, selectedCodecQn);
 
-        match_qn_success:
-            this.logger.Debug("设置画质 {QnSettings}, 可用画质 {AcceptQn}, 最终选择 {SelectedQn}", allowedQn, allAvailableCodecQn, selectedCodecQn);
-
-            if (selectedCodecQn.Qn != DefaultQn)
-            {
-                // 最终选择的 qn 与默认不同，需要重新请求一次
-                codecItems = await this.apiClient.GetCodecItemInStreamUrlAsync(roomid: roomid, qn: selectedCodecQn.Qn).ConfigureAwait(false);
-            }
+            // 使用最终选择的 qn 重新请求一次，拿到对应的直播流地址
+            var codecItems = await this.apiClient.GetCodecItemInStreamUrlAsync(roomid: roomid, qn: selectedCodecQn.Qn).ConfigureAwait(false);
 
             var item = selectedCodecQn.Codec switch
             {
@@ -364,7 +285,7 @@ namespace BililiveRecorder.Core.Recording
 
             var fullUrl = url_info.Host + item.BaseUrl + url_info.Extra;
 
-            return (fullUrl, new StreamCodecQn { Codec = selectedCodecQn.Codec, Qn = item.CurrentQn });
+            return (fullUrl, selectedCodecQn, new StreamCodecQn { Codec = selectedCodecQn.Codec, Qn = item.CurrentQn });
         }
 
         protected async Task<Stream> GetStreamAsync(string fullUrl, int timeout)

--- a/BililiveRecorder.Core/Room.cs
+++ b/BililiveRecorder.Core/Room.cs
@@ -32,6 +32,7 @@ namespace BililiveRecorder.Core
         private readonly object recordStartLock = new object();
         private readonly SemaphoreSlim recordRetryDelaySemaphoreSlim = new SemaphoreSlim(1, 1);
         private readonly Timer timer;
+        private readonly Timer qualityUpgradeTimer;
 
         private readonly IServiceScope scope;
         private readonly ILogger loggerWithoutContext;
@@ -83,6 +84,7 @@ namespace BililiveRecorder.Core
             this.userScriptRunner = userScriptRunner ?? throw new ArgumentNullException(nameof(userScriptRunner));
 
             this.timer = new Timer(this.RoomConfig.TimingCheckInterval * 1000d);
+            this.qualityUpgradeTimer = new Timer(this.RoomConfig.TimingQualityUpgradeCheckInterval * 1000d);
             this.cts = new CancellationTokenSource();
             this.ct = this.cts.Token;
 
@@ -90,6 +92,7 @@ namespace BililiveRecorder.Core
             this.RoomConfig.PropertyChanged += this.RoomConfig_PropertyChanged;
 
             this.timer.Elapsed += this.Timer_Elapsed;
+            this.qualityUpgradeTimer.Elapsed += this.QualityUpgradeTimer_Elapsed;
 
             this.danmakuClient.StatusChanged += this.DanmakuClient_StatusChanged;
             this.danmakuClient.DanmakuReceived += this.DanmakuClient_DanmakuReceived;
@@ -99,6 +102,8 @@ namespace BililiveRecorder.Core
             {
                 await Task.Delay(1500 + (initDelayFactor * 500));
                 this.timer.Start();
+                if (this.RoomConfig.RecordingQualityUpgradeCheck)
+                    this.qualityUpgradeTimer.Start();
                 await this.RefreshRoomInfoAsync();
             });
         }
@@ -698,6 +703,69 @@ namespace BililiveRecorder.Core
         }
 
 
+        private void QualityUpgradeTimer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
+        {
+            if (this.disposedValue || !this.RoomConfig.RecordingQualityUpgradeCheck)
+                return;
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await this.CheckAndUpgradeQualityAsync().ConfigureAwait(false);
+                }
+                catch (Exception) { }
+            });
+        }
+
+        private async Task CheckAndUpgradeQualityAsync()
+        {
+            if (this.disposedValue)
+                return;
+
+            IRecordTask? task;
+            lock (this.recordStartLock)
+            {
+                task = this.recordTask;
+            }
+
+            if (task is null || !this.Streaming || !this.AutoRecordForThisSession)
+                return;
+
+            var allowedQn = StreamQualitySelector.ParseAllowedQn(this.RoomConfig.RecordingQuality);
+            if (allowedQn.Count == 0)
+                return;
+
+            var current = task.CurrentCodecQn;
+            var currentIndex = StreamQualitySelector.IndexOfQn(allowedQn, current);
+            if (currentIndex < 0)
+                return; // 当前画质不在设置列表（例如用户脚本返回的流），跳过
+
+            StreamCodecQn best;
+            try
+            {
+                best = await StreamQualitySelector.SelectBestAvailableAsync(this.apiClient, allowedQn, this.RoomConfig.RoomId).ConfigureAwait(false);
+            }
+            catch (NoMatchingQnValueException)
+            {
+                return; // 当前无可用画质匹配，等下次再检查
+            }
+
+            var bestIndex = StreamQualitySelector.IndexOfQn(allowedQn, best);
+            if (bestIndex < 0 || bestIndex >= currentIndex)
+                return; // 没有更高优先级的画质
+
+            this.logger.Information("检测到更高优先级画质 {Best} (当前 {Current})，将重新开始录制", best, current);
+
+            lock (this.recordStartLock)
+            {
+                // 停止当前录制；录制结束后会经由 RecordSessionEnded 自动开始新录制
+                if (this.recordTask is not null && this.recordTask.SessionId == task.SessionId)
+                    this.recordTask.RequestStop();
+            }
+        }
+
+
         private void Room_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
@@ -734,6 +802,15 @@ namespace BililiveRecorder.Core
                     break;
                 case nameof(this.RoomConfig.TimingCheckInterval):
                     this.timer.Interval = this.RoomConfig.TimingCheckInterval * 1000d;
+                    break;
+                case nameof(this.RoomConfig.TimingQualityUpgradeCheckInterval):
+                    this.qualityUpgradeTimer.Interval = this.RoomConfig.TimingQualityUpgradeCheckInterval * 1000d;
+                    break;
+                case nameof(this.RoomConfig.RecordingQualityUpgradeCheck):
+                    if (this.RoomConfig.RecordingQualityUpgradeCheck)
+                        this.qualityUpgradeTimer.Start();
+                    else
+                        this.qualityUpgradeTimer.Stop();
                     break;
                 case nameof(this.RoomConfig.AutoRecord):
                     if (this.RoomConfig.AutoRecord)
@@ -782,6 +859,8 @@ namespace BililiveRecorder.Core
                     // dispose managed state (managed objects)
                     this.cts.Cancel();
                     this.cts.Dispose();
+                    this.qualityUpgradeTimer.Stop();
+                    this.qualityUpgradeTimer.Dispose();
                     this.recordTask?.RequestStop();
                     this.basicDanmakuWriter.Disable();
                     this.scope.Dispose();

--- a/BililiveRecorder.WPF/Pages/AdvancedSettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/AdvancedSettingsPage.xaml
@@ -115,10 +115,7 @@
                         </c:SettingWithDefault.ToolTip>
                         <ui:NumberBox Minimum="10" Description="单位: 秒" SmallChange="5" Text="{Binding TimingStreamRetryNoQn,Delay=500}"/>
                     </c:SettingWithDefault>
-                    <c:SettingWithDefault IsSettingNotUsingDefault="{Binding HasRecordingQualityUpgradeCheck}">
-                        <ui:ToggleSwitch IsOn="{Binding RecordingQualityUpgradeCheck}" OnContent="自动升级画质" OffContent="自动升级画质"/>
-                    </c:SettingWithDefault>
-                    <c:SettingWithDefault IsSettingNotUsingDefault="{Binding HasTimingQualityUpgradeCheckInterval}" Header="画质升级检查间隔">
+                    <c:SettingWithDefault IsSettingNotUsingDefault="{Binding HasTimingQualityUpgradeCheckInterval}" Header="画质更新检查间隔">
                         <c:SettingWithDefault.ToolTip>
                             <TextBlock>
                                 每隔多长时间检查一次是否有更高优先级的画质可用<LineBreak/>

--- a/BililiveRecorder.WPF/Pages/AdvancedSettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/AdvancedSettingsPage.xaml
@@ -115,6 +115,18 @@
                         </c:SettingWithDefault.ToolTip>
                         <ui:NumberBox Minimum="10" Description="单位: 秒" SmallChange="5" Text="{Binding TimingStreamRetryNoQn,Delay=500}"/>
                     </c:SettingWithDefault>
+                    <c:SettingWithDefault IsSettingNotUsingDefault="{Binding HasRecordingQualityUpgradeCheck}">
+                        <ui:ToggleSwitch IsOn="{Binding RecordingQualityUpgradeCheck}" OnContent="自动升级画质" OffContent="自动升级画质"/>
+                    </c:SettingWithDefault>
+                    <c:SettingWithDefault IsSettingNotUsingDefault="{Binding HasTimingQualityUpgradeCheckInterval}" Header="画质升级检查间隔">
+                        <c:SettingWithDefault.ToolTip>
+                            <TextBlock>
+                                每隔多长时间检查一次是否有更高优先级的画质可用<LineBreak/>
+                                检测到更优画质后会结束当前录制并立即重新开始
+                            </TextBlock>
+                        </c:SettingWithDefault.ToolTip>
+                        <ui:NumberBox Minimum="10" Description="单位: 秒" SmallChange="5" Text="{Binding TimingQualityUpgradeCheckInterval,Delay=500}"/>
+                    </c:SettingWithDefault>
                     <c:SettingWithDefault IsSettingNotUsingDefault="{Binding HasTimingStreamConnect}" Header="录制连接超时">
                         <c:SettingWithDefault.ToolTip>
                             <TextBlock>

--- a/BililiveRecorder.WPF/Pages/SettingsPage.xaml
+++ b/BililiveRecorder.WPF/Pages/SettingsPage.xaml
@@ -130,6 +130,9 @@
                         <TextBox Text="{Binding RecordingQuality,UpdateSourceTrigger=PropertyChanged,Delay=1000}"
                                  ui:TextBoxHelper.IsDeleteButtonVisible="False" Width="220" HorizontalAlignment="Left"/>
                     </c:SettingWithDefault>
+                    <c:SettingWithDefault IsSettingNotUsingDefault="{Binding HasRecordingQualityUpgradeCheck}">
+                        <ui:ToggleSwitch IsOn="{Binding RecordingQualityUpgradeCheck}" OnContent="自动更新优先画质（实验性选项）" OffContent="自动更新优先画质（实验性选项）"/>
+                    </c:SettingWithDefault>
                 </StackPanel>
             </GroupBox>
             <GroupBox Header="录制条件">

--- a/BililiveRecorder.Web/Models/Config.gen.cs
+++ b/BililiveRecorder.Web/Models/Config.gen.cs
@@ -76,6 +76,8 @@ namespace BililiveRecorder.Web.Models
         public Optional<uint>? OptionalTimingApiTimeout { get; set; }
         public Optional<uint>? OptionalTimingStreamRetry { get; set; }
         public Optional<uint>? OptionalTimingStreamRetryNoQn { get; set; }
+        public Optional<bool>? OptionalRecordingQualityUpgradeCheck { get; set; }
+        public Optional<uint>? OptionalTimingQualityUpgradeCheckInterval { get; set; }
         public Optional<uint>? OptionalTimingStreamConnect { get; set; }
         public Optional<uint>? OptionalTimingDanmakuRetry { get; set; }
         public Optional<uint>? OptionalTimingWatchdogTimeout { get; set; }
@@ -114,6 +116,8 @@ namespace BililiveRecorder.Web.Models
             if (this.OptionalTimingApiTimeout.HasValue) config.OptionalTimingApiTimeout = this.OptionalTimingApiTimeout.Value;
             if (this.OptionalTimingStreamRetry.HasValue) config.OptionalTimingStreamRetry = this.OptionalTimingStreamRetry.Value;
             if (this.OptionalTimingStreamRetryNoQn.HasValue) config.OptionalTimingStreamRetryNoQn = this.OptionalTimingStreamRetryNoQn.Value;
+            if (this.OptionalRecordingQualityUpgradeCheck.HasValue) config.OptionalRecordingQualityUpgradeCheck = this.OptionalRecordingQualityUpgradeCheck.Value;
+            if (this.OptionalTimingQualityUpgradeCheckInterval.HasValue) config.OptionalTimingQualityUpgradeCheckInterval = this.OptionalTimingQualityUpgradeCheckInterval.Value;
             if (this.OptionalTimingStreamConnect.HasValue) config.OptionalTimingStreamConnect = this.OptionalTimingStreamConnect.Value;
             if (this.OptionalTimingDanmakuRetry.HasValue) config.OptionalTimingDanmakuRetry = this.OptionalTimingDanmakuRetry.Value;
             if (this.OptionalTimingWatchdogTimeout.HasValue) config.OptionalTimingWatchdogTimeout = this.OptionalTimingWatchdogTimeout.Value;
@@ -177,6 +181,8 @@ namespace BililiveRecorder.Web.Models.Rest
         public Optional<uint> OptionalTimingApiTimeout { get; set; }
         public Optional<uint> OptionalTimingStreamRetry { get; set; }
         public Optional<uint> OptionalTimingStreamRetryNoQn { get; set; }
+        public Optional<bool> OptionalRecordingQualityUpgradeCheck { get; set; }
+        public Optional<uint> OptionalTimingQualityUpgradeCheckInterval { get; set; }
         public Optional<uint> OptionalTimingStreamConnect { get; set; }
         public Optional<uint> OptionalTimingDanmakuRetry { get; set; }
         public Optional<uint> OptionalTimingWatchdogTimeout { get; set; }
@@ -245,6 +251,8 @@ namespace BililiveRecorder.Web.Models.Graphql
             this.Field(x => x.OptionalTimingApiTimeout, type: typeof(HierarchicalOptionalType<uint>));
             this.Field(x => x.OptionalTimingStreamRetry, type: typeof(HierarchicalOptionalType<uint>));
             this.Field(x => x.OptionalTimingStreamRetryNoQn, type: typeof(HierarchicalOptionalType<uint>));
+            this.Field(x => x.OptionalRecordingQualityUpgradeCheck, type: typeof(HierarchicalOptionalType<bool>));
+            this.Field(x => x.OptionalTimingQualityUpgradeCheckInterval, type: typeof(HierarchicalOptionalType<uint>));
             this.Field(x => x.OptionalTimingStreamConnect, type: typeof(HierarchicalOptionalType<uint>));
             this.Field(x => x.OptionalTimingDanmakuRetry, type: typeof(HierarchicalOptionalType<uint>));
             this.Field(x => x.OptionalTimingWatchdogTimeout, type: typeof(HierarchicalOptionalType<uint>));
@@ -287,6 +295,8 @@ namespace BililiveRecorder.Web.Models.Graphql
             this.Field(x => x.TimingApiTimeout);
             this.Field(x => x.TimingStreamRetry);
             this.Field(x => x.TimingStreamRetryNoQn);
+            this.Field(x => x.RecordingQualityUpgradeCheck);
+            this.Field(x => x.TimingQualityUpgradeCheckInterval);
             this.Field(x => x.TimingStreamConnect);
             this.Field(x => x.TimingDanmakuRetry);
             this.Field(x => x.TimingWatchdogTimeout);
@@ -351,6 +361,8 @@ namespace BililiveRecorder.Web.Models.Graphql
             this.Field(x => x.OptionalTimingApiTimeout, nullable: true, type: typeof(HierarchicalOptionalInputType<uint>));
             this.Field(x => x.OptionalTimingStreamRetry, nullable: true, type: typeof(HierarchicalOptionalInputType<uint>));
             this.Field(x => x.OptionalTimingStreamRetryNoQn, nullable: true, type: typeof(HierarchicalOptionalInputType<uint>));
+            this.Field(x => x.OptionalRecordingQualityUpgradeCheck, nullable: true, type: typeof(HierarchicalOptionalInputType<bool>));
+            this.Field(x => x.OptionalTimingQualityUpgradeCheckInterval, nullable: true, type: typeof(HierarchicalOptionalInputType<uint>));
             this.Field(x => x.OptionalTimingStreamConnect, nullable: true, type: typeof(HierarchicalOptionalInputType<uint>));
             this.Field(x => x.OptionalTimingDanmakuRetry, nullable: true, type: typeof(HierarchicalOptionalInputType<uint>));
             this.Field(x => x.OptionalTimingWatchdogTimeout, nullable: true, type: typeof(HierarchicalOptionalInputType<uint>));

--- a/configV3.schema.json
+++ b/configV3.schema.json
@@ -207,6 +207,40 @@
             }
           }
         },
+        "RecordingQualityUpgradeCheck": {
+          "description": "自动升级画质\n默认: false",
+          "markdownDescription": "自动升级画质  \n默认: `false `\n\n",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "HasValue": {
+              "type": "boolean",
+              "default": true
+            },
+            "Value": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "TimingQualityUpgradeCheckInterval": {
+          "description": "画质升级检查间隔 秒\n默认: 60",
+          "markdownDescription": "画质升级检查间隔 秒  \n默认: `60 `\n\n",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "HasValue": {
+              "type": "boolean",
+              "default": true
+            },
+            "Value": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 4294967295,
+              "default": 60
+            }
+          }
+        },
         "TimingStreamConnect": {
           "description": "连接直播服务器超时时间 毫秒\n默认: 5000",
           "markdownDescription": "连接直播服务器超时时间 毫秒  \n默认: `5000 `\n\n",

--- a/configV3.schema.json
+++ b/configV3.schema.json
@@ -208,8 +208,8 @@
           }
         },
         "RecordingQualityUpgradeCheck": {
-          "description": "自动升级画质\n默认: false",
-          "markdownDescription": "自动升级画质  \n默认: `false `\n\n",
+          "description": "自动更新优先画质\n默认: false",
+          "markdownDescription": "自动更新优先画质  \n默认: `false `\n\n",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -224,8 +224,8 @@
           }
         },
         "TimingQualityUpgradeCheckInterval": {
-          "description": "画质升级检查间隔 秒\n默认: 60",
-          "markdownDescription": "画质升级检查间隔 秒  \n默认: `60 `\n\n",
+          "description": "画质更新检查间隔 秒\n默认: 90",
+          "markdownDescription": "画质更新检查间隔 秒  \n默认: `90 `\n\n",
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -237,7 +237,7 @@
               "type": "integer",
               "minimum": 0,
               "maximum": 4294967295,
-              "default": 60
+              "default": 90
             }
           }
         },

--- a/config_gen/data.ts
+++ b/config_gen/data.ts
@@ -207,7 +207,7 @@ export const data: Array<ConfigEntry> = [
     },
     {
         id: "RecordingQualityUpgradeCheck",
-        name: "自动升级画质",
+        name: "自动更新优先画质",
         type: "bool",
         configType: "globalOnly",
         advancedConfig: true,
@@ -215,11 +215,11 @@ export const data: Array<ConfigEntry> = [
     },
     {
         id: "TimingQualityUpgradeCheckInterval",
-        name: "画质升级检查间隔 秒",
+        name: "画质更新检查间隔 秒",
         type: "uint",
         configType: "globalOnly",
         advancedConfig: true,
-        default: 60,
+        default: 90,
     },
     {
         id: "TimingStreamConnect",

--- a/config_gen/data.ts
+++ b/config_gen/data.ts
@@ -206,6 +206,22 @@ export const data: Array<ConfigEntry> = [
         default: 90,
     },
     {
+        id: "RecordingQualityUpgradeCheck",
+        name: "自动升级画质",
+        type: "bool",
+        configType: "globalOnly",
+        advancedConfig: true,
+        default: false,
+    },
+    {
+        id: "TimingQualityUpgradeCheckInterval",
+        name: "画质升级检查间隔 秒",
+        type: "uint",
+        configType: "globalOnly",
+        advancedConfig: true,
+        default: 60,
+    },
+    {
         id: "TimingStreamConnect",
         name: "连接直播服务器超时时间 毫秒",
         type: "uint",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "latestMajor"
+    "rollForward": "latestFeature"
   }
 }

--- a/quality-upgrade-changelog.md
+++ b/quality-upgrade-changelog.md
@@ -1,0 +1,83 @@
+# 画质自动升级功能 — 变更记录
+
+## 功能概述
+
+新增可选功能：**自动升级画质**。
+
+开启后，每隔一定时间（`TimingQualityUpgradeCheckInterval`）检查一次当前直播是否有更高优先级的画质可用；
+若发现更优画质（在 `RecordingQuality` 列表中出现得更靠前），则结束当前录制并立即重新开始录制，从而切换到更高画质。
+
+默认**关闭**，不影响现有行为。
+
+## 新增配置项（均为全局、高级设置）
+
+| id | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `RecordingQualityUpgradeCheck` | bool | `false` | 是否启用自动升级画质 |
+| `TimingQualityUpgradeCheckInterval` | uint | `60` | 画质升级检查间隔（秒） |
+
+> 说明：画质优先级由 `RecordingQuality`（如 `avc10000,hevc10000`）中的**先后顺序**决定，越靠前优先级越高。
+
+## 核心实现逻辑
+
+1. 抽取画质解析/选择逻辑到新类 `BililiveRecorder.Core/Api/StreamQualitySelector.cs`：
+   - `ParseAllowedQn`：把 `RecordingQuality` 解析为有序的 `StreamCodecQn` 列表（顺序即优先级）。
+   - `SelectBestAvailableAsync`：请求可用画质并返回第一个匹配的（最优）。
+   - `IndexOfQn`：返回某画质在优先级列表中的下标。
+2. `RecordTaskBase` 通过 `CurrentCodecQn` 暴露当前录制**选中的画质**（接口 `IRecordTask` 同步暴露）。
+3. `Room` 新增独立定时器 `qualityUpgradeTimer`，周期调用 `CheckAndUpgradeQualityAsync`：
+   - 取当前录制的画质下标 `currentIndex` 与当前最优画质下标 `bestIndex`。
+   - 若 `bestIndex < currentIndex`，调用 `recordTask.RequestStop()`。
+   - 录制停止后，由已有的 `RecordSessionEnded` 逻辑自动启动新录制，新录制会选中更高画质。
+
+## 修改文件清单
+
+### 核心逻辑
+
+- `BililiveRecorder.Core/Api/StreamQualitySelector.cs`（新增）
+- `BililiveRecorder.Core/Recording/IRecordTask.cs`：新增 `CurrentCodecQn`
+- `BililiveRecorder.Core/Recording/RecordTaskBase.cs`：暴露画质、复用 `StreamQualitySelector`
+- `BililiveRecorder.Core/Room.cs`：新增画质升级定时检查
+
+### 配置定义与生成产物
+
+- `config_gen/data.ts`（源）
+- `BililiveRecorder.Core/Config/V3/Config.gen.cs`
+- `BililiveRecorder.Cli/Configure/ConfigInstructions.gen.cs`
+- `BililiveRecorder.Web/Models/Config.gen.cs`（DTO + GraphQL 输入/输出/默认值类型）
+- `configV3.schema.json`
+
+### UI
+
+- `BililiveRecorder.WPF/Pages/AdvancedSettingsPage.xaml`
+- `webui/source/src/utils/api.ts`
+- `webui/source/src/views/recorder/SettingPage.vue`
+
+## 待完成项 / 注意事项
+
+1. ~~**编译验证**~~（已完成）：在 .NET SDK 8.0.424 下构建：
+   - `BililiveRecorder.Core`（net472 + net8.0）、`BililiveRecorder.Web`、`BililiveRecorder.Cli`、`BililiveRecorder.ToolBox`、`BililiveRecorder.Flv` 均构建成功。
+   - 核心单元测试 `BililiveRecorder.Core.UnitTests`（net8.0）：**142 通过 / 0 失败 / 1 跳过**。
+   - WPF 项目因 NuGet 依赖还原问题（`CS0246` 找不到 ModernWpf/Serilog 等命名空间）仍无法编译，属该项目的既有构建方式问题、与本次改动无关。见下方「WPF 构建」。
+2. ~~**Web 版启动与配置验证**~~（已完成）：以 CLI `run` 模式启动内嵌 Web 服务器（`http://localhost:2356`），验证：
+   - `GET /api/config/default` 返回 `recordingQualityUpgradeCheck: false`、`timingQualityUpgradeCheckInterval: 60`。
+   - `GET /api/config/global` 返回 `optionalRecordingQualityUpgradeCheck`、`optionalTimingQualityUpgradeCheckInterval`。
+   - `POST /api/config/global` 可写入 `{hasValue:true, value:true}` / `{hasValue:true, value:30}`，返回 200。
+   - 配置正确持久化到 `config.json`：`{"version":3,"global":{"RecordingQualityUpgradeCheck":{"HasValue":true,"Value":true},"TimingQualityUpgradeCheckInterval":{"HasValue":true,"Value":30}},...}`。
+3. ~~**Release 发布**~~（已完成）：
+   - 构建 WebUI 前端：`cd webui/source && npm ci && npx vite build`，产物拷贝到 `BililiveRecorder.Web/embeded/ui`（含画质升级设置界面）。
+   - 发布自包含版本：`dotnet publish BililiveRecorder.Cli/BililiveRecorder.Cli.csproj -c Release -r win-x64 --self-contained true`。
+   - 产物目录：`BililiveRecorder.Cli/publish/win-x64/Release/`（主程序 `BililiveRecorder.Cli.exe`，403 个文件共约 115 MB）。
+   - 已验证：启动后 `/ui/` 返回 200，新 Vue UI 的 `assets/index-c4567335.js`（888 KB）与 `index-4f0b3bfb.css` 均可正常加载；`/api/config/default` 返回新配置项。
+   - 其它平台：将 `-r` 改为 `linux-x64`、`linux-arm64`、`osx-x64` 等即可（csproj 已声明 RuntimeIdentifiers）。
+4. **CLI 配置向导**：`ConfigInstructions.gen.cs` 已同步新增两个配置项（枚举项 + `ConfigInstruction` 条目），与生成器 `codeCli.ts` 输出一致。
+5. **生成器复验**：生成产物文件为手动按生成器模板同步编写，建议在装有 Node 的环境执行 `cd config_gen && npm install && npm run build -- code` 复核一致。
+6. **WPF 构建**：WPF 目标是 .NET Framework 4.7.2，README 要求用 `msbuild -t:restore && msbuild` 而非 `dotnet build`。
+   当前 `dotnet build` 报 `CS0246`（找不到 NuGet 包命名空间），是还原方式问题。如要验证 WPF 的 XAML 改动，请在 Developer Command Prompt 里按 README 执行 `msbuild -t:restore` 后 `msbuild`。
+7. **文档**：`config_gen/generators/doc.ts` 生成的网站文档未更新（不在本仓库核心范围内）。
+8. **V2 配置**：`BililiveRecorder.Core/Config/V2` 与 `configV2.schema.json` 为历史迁移格式，未改动（新配置项仅用于 V3，旧配置升级后默认关闭）。
+9. **建议端到端测试**（需真实直播流）：
+   - 开启开关后，主播从低画质升到高画质时，应能自动重开录制到更高画质。
+   - 已是最优画质时不反复重启。
+   - 用户脚本返回直播流（`qn = -1`）时跳过升级检查。
+   - 关闭开关后不再检查、不再重启。

--- a/quality-upgrade-changelog.md
+++ b/quality-upgrade-changelog.md
@@ -2,9 +2,9 @@
 
 ## 功能概述
 
-新增可选功能：**自动升级画质**。
+新增可选功能：**自动更新优先画质**。
 
-开启后，每隔一定时间（`TimingQualityUpgradeCheckInterval`）检查一次当前直播是否有更高优先级的画质可用；
+开启后，每隔一定时间（`TimingQualityUpgradeCheckInterval`，默认 90 秒）检查一次当前直播是否有更高优先级的画质可用；
 若发现更优画质（在 `RecordingQuality` 列表中出现得更靠前），则结束当前录制并立即重新开始录制，从而切换到更高画质。
 
 默认**关闭**，不影响现有行为。
@@ -13,8 +13,8 @@
 
 | id | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `RecordingQualityUpgradeCheck` | bool | `false` | 是否启用自动升级画质 |
-| `TimingQualityUpgradeCheckInterval` | uint | `60` | 画质升级检查间隔（秒） |
+| `RecordingQualityUpgradeCheck` | bool | `false` | 是否启用自动更新优先画质 |
+| `TimingQualityUpgradeCheckInterval` | uint | `90` | 画质更新检查间隔（秒） |
 
 > 说明：画质优先级由 `RecordingQuality`（如 `avc10000,hevc10000`）中的**先后顺序**决定，越靠前优先级越高。
 


### PR DESCRIPTION
### 添加录制画质自动切换功能：

- 录制开始后，间隔一定时间检查是否存在优先级更高的录制画质，若存在则重启录制

- 该功能默认关闭，需要在设置页面手动打开"自动更新优先画质（实验性选项）"

- 间隔时间默认90秒，可以在高级设置中设置"画质更新检查时间间隔"

目前仅测试了win11中WPF和CLI版，功能正常。使用DeepSeek辅助编写